### PR TITLE
Improved support for Azure App Services and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-The simplest LetsEncrypt setup for ASP .NET Core. Almost no server configuration needed.
+The simplest LetsEncrypt setup for ASP .NET Core. Almost no server configuration needed. 
 
 `Install-Package FluffySpoon.AspNet.LetsEncrypt`
-
+ 
 # Requirements
 - Kestrel (which is default)
 - ASP .NET Core 2.1+
 - An always-on app-pool
 
 ## Getting an always-on app pool
-This is required because the renewal job runs on a background thread and polls once every hour to see if the certificate needs renewal (this is a very cheap operation).
+This is required because the renewal job runs on a background thread and polls once every hour to see if the certificate needs renewal (this is a very cheap operation). 
 
 It can be enabled using __just one__ the following techniques:
 - Enabling Always On if using Azure App Service.
@@ -67,7 +67,7 @@ Finally, to make Kestrel automatically select the LetsEncrypt certificate, we mu
 ```csharp
 WebHost.CreateDefaultBuilder(args)
 	.UseKestrel(kestrelOptions => kestrelOptions.ConfigureHttpsDefaults(
-			httpsOptions => httpsOptions.ServerCertificateSelector =
+			httpsOptions => httpsOptions.ServerCertificateSelector = 
 				(c, s) => LetsEncryptRenewalService.Certificate))
 	.UseUrls("http://" + DomainToUse, "https://" + DomainToUse)
 	.UseStartup<Startup>();

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/FluffySpoon.AspNet.LetsEncrypt.Azure.csproj
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/FluffySpoon.AspNet.LetsEncrypt.Azure.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.18.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Certes;
 
@@ -32,5 +32,10 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 		/// Required. Sent to LetsEncrypt to let them know what details you want in your certificate. Some of the properties are optional.
 		/// </summary>
 		public CsrInfo CertificateSigningRequest { get; set; }
+
+        /// <summary>
+        /// Gets or sets the renewal fail mode - i.e. what happens if an exception is thrown in the certificate renewal process.
+        /// </summary>
+        public RenewalFailMode RenewalFailMode { get; set; } = RenewalFailMode.Unhandled;
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
@@ -33,9 +33,9 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 		/// </summary>
 		public CsrInfo CertificateSigningRequest { get; set; }
 
-        /// <summary>
-        /// Gets or sets the renewal fail mode - i.e. what happens if an exception is thrown in the certificate renewal process.
-        /// </summary>
-        public RenewalFailMode RenewalFailMode { get; set; } = RenewalFailMode.Unhandled;
+		/// <summary>
+		/// Gets or sets the renewal fail mode - i.e. what happens if an exception is thrown in the certificate renewal process.
+		/// </summary>
+		public RenewalFailMode RenewalFailMode { get; set; } = RenewalFailMode.Unhandled;
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptOptions.cs
@@ -36,6 +36,6 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 		/// <summary>
 		/// Gets or sets the renewal fail mode - i.e. what happens if an exception is thrown in the certificate renewal process.
 		/// </summary>
-		public RenewalFailMode RenewalFailMode { get; set; } = RenewalFailMode.Unhandled;
+		public RenewalFailMode RenewalFailMode { get; set; } = RenewalFailMode.LogAndContinue;
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptRenewalService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptRenewalService.cs
@@ -65,8 +65,8 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 			foreach (var lifecycleHook in _lifecycleHooks)
 				await lifecycleHook.OnStartAsync();
 
-            _timer = new Timer(async (state) => RunOnceWithErrorHandling(), null, TimeSpan.Zero, TimeSpan.FromHours(1));
-        }
+			_timer = new Timer(async (state) => RunOnceWithErrorHandling(), null, TimeSpan.Zero, TimeSpan.FromHours(1));
+		}
 
 		public async Task StopAsync(CancellationToken cancellationToken)
 		{
@@ -99,24 +99,24 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 			return false;
 		}
 
-        private async Task RunOnceWithErrorHandling()
-        {
-            try
-            {
-                await RunOnceAsync();
-                _timer.Change(Timeout.InfiniteTimeSpan, TimeSpan.FromHours(1));
-            }
-            catch (Exception e) when (_options.RenewalFailMode != RenewalFailMode.Unhandled)
-            {
-                _logger.LogWarning(e, $"Exception occured renewing certificates: '{e.Message}.'");
-                if (_options.RenewalFailMode == RenewalFailMode.LogAndRetry)
-                    _timer.Change(Timeout.InfiniteTimeSpan, TimeSpan.FromMinutes(1));
-            }
-        }
+		private async Task RunOnceWithErrorHandling()
+		{
+			try
+			{
+				await RunOnceAsync();
+				_timer.Change(Timeout.InfiniteTimeSpan, TimeSpan.FromHours(1));
+			}
+			catch (Exception e) when (_options.RenewalFailMode != RenewalFailMode.Unhandled)
+			{
+				_logger.LogWarning(e, $"Exception occured renewing certificates: '{e.Message}.'");
+				if (_options.RenewalFailMode == RenewalFailMode.LogAndRetry)
+					_timer.Change(Timeout.InfiniteTimeSpan, TimeSpan.FromMinutes(1));
+			}
+		}
 
-        public async Task RunOnceAsync()
-        {
-            if (_semaphoreSlim.CurrentCount == 0)
+		public async Task RunOnceAsync()
+		{
+			if (_semaphoreSlim.CurrentCount == 0)
 				return;
 
 			await _semaphoreSlim.WaitAsync();

--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptRenewalService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptRenewalService.cs
@@ -65,7 +65,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 			foreach (var lifecycleHook in _lifecycleHooks)
 				await lifecycleHook.OnStartAsync();
 
-			_timer = new Timer(async (state) => RunOnceWithErrorHandling(), null, TimeSpan.Zero, TimeSpan.FromHours(1));
+			_timer = new Timer(async (state) => await RunOnceWithErrorHandlingAsync(), null, TimeSpan.Zero, TimeSpan.FromHours(1));
 		}
 
 		public async Task StopAsync(CancellationToken cancellationToken)
@@ -99,7 +99,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 			return false;
 		}
 
-		private async Task RunOnceWithErrorHandling()
+		private async Task RunOnceWithErrorHandlingAsync()
 		{
 			try
 			{

--- a/src/FluffySpoon.AspNet.LetsEncrypt/RenewalFailMode.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/RenewalFailMode.cs
@@ -1,0 +1,23 @@
+﻿namespace FluffySpoon.AspNet.LetsEncrypt
+{
+    /// <summary>
+    /// Defines the ways errors are handle by the <see cref="ILetsEncryptRenewalService" />.
+    /// </summary>
+    public enum RenewalFailMode
+    {
+        /// <summary>
+        /// Throw any exceptions out of the service's context, thus causing an unhandled exception that will crash the application if not handled elsewhere.
+        /// </summary>
+        Unhandled,
+
+        /// <summary>
+        /// Log exceptions and continue normal operation.
+        /// </summary>
+        LogAndContinue,
+
+        /// <summary>
+        /// Log exceptions and retry sooner than normal.
+        /// </summary>
+        LogAndRetry
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/RenewalFailMode.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/RenewalFailMode.cs
@@ -1,23 +1,23 @@
 ﻿namespace FluffySpoon.AspNet.LetsEncrypt
 {
-    /// <summary>
-    /// Defines the ways errors are handle by the <see cref="ILetsEncryptRenewalService" />.
-    /// </summary>
-    public enum RenewalFailMode
-    {
-        /// <summary>
-        /// Throw any exceptions out of the service's context, thus causing an unhandled exception that will crash the application if not handled elsewhere.
-        /// </summary>
-        Unhandled,
+	/// <summary>
+	/// Defines the ways errors are handle by the <see cref="ILetsEncryptRenewalService" />.
+	/// </summary>
+	public enum RenewalFailMode
+	{
+		/// <summary>
+		/// Throw any exceptions out of the service's context, thus causing an unhandled exception that will crash the application if not handled elsewhere.
+		/// </summary>
+		Unhandled,
 
-        /// <summary>
-        /// Log exceptions and continue normal operation.
-        /// </summary>
-        LogAndContinue,
+		/// <summary>
+		/// Log exceptions and continue normal operation.
+		/// </summary>
+		LogAndContinue,
 
-        /// <summary>
-        /// Log exceptions and retry sooner than normal.
-        /// </summary>
-        LogAndRetry
-    }
+		/// <summary>
+		/// Log exceptions and retry sooner than normal.
+		/// </summary>
+		LogAndRetry
+	}
 }


### PR DESCRIPTION
I've done 3 related things:

- Updated the Azure management packages so they now support Managed Identity
- Expand the description of using the package in an Azure App Service
- Made exception handling in the service configurable: now you can choose whether to crash the app or log any exceptions, if the renewal process fails for some reason.

The 2 first items should be quite self explanatory. The 3. was done because I had trouble finding out what was happening during the renewal process, because the exception (caused by permission issues) didn't get logged properly due to the app crashing.