### PR TITLE
Azure certificate retrieval fix

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -328,12 +328,12 @@ namespace FluffySpoon.LetsEncrypt.Azure
 		{
 			var azureCert = await GetExistingAzureCertificateAsync(persistenceType);
 
-			X509Store certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+			var certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
 			certStore.Open(OpenFlags.ReadOnly);
 
 			try
 			{
-				X509Certificate2Collection certCollection = certStore.Certificates.Find(
+				var certCollection = certStore.Certificates.Find(
 											X509FindType.FindByThumbprint,
 											// Replace below with your certificate's thumbprint
 											azureCert.Thumbprint,
@@ -342,7 +342,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 				// Get the first cert with the thumbprint
 				if (certCollection.Count > 0)
 				{
-					X509Certificate2 cert = certCollection[0];
+					var cert = certCollection[0];
 					return cert;
 				}
 			}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -252,7 +252,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 				var certThumbprintsToLoad = loadCertificatesSetting.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
 				if (!certThumbprintsToLoad.Contains(azureCertificate.Thumbprint))
 				{
-					logger.LogInformation($"Adding certificate thumbprint {azureCertificate.Thumbprint} to WEBSITE_LOAD_CERTIFICATES app setting");
+					logger.LogInformation("Adding certificate thumbprint {0} to WEBSITE_LOAD_CERTIFICATES app setting", azureCertificate.Thumbprint);
 
 					certThumbprintsToLoad.Add(azureCertificate.Thumbprint);
 
@@ -269,7 +269,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 					}
 					catch (Exception ex)
 					{
-						logger.LogError(ex, $"Error updating app settings for {appTuple.App.Name}");
+						logger.LogError(ex, "Error updating app settings for {0}", appTuple.App.Name);
 					}
 				}
 			}
@@ -281,7 +281,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 
 			if (certificate == null)
 			{
-				logger.LogInformation($"Certificate of type {persistenceType} not found.");
+				logger.LogInformation("Certificate of type {0} not found.", persistenceType);
 				return null;
 			}
 
@@ -289,7 +289,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 
 			if (pfxBlob == null || pfxBlob.Length == 0)
 			{
-				logger.LogError($"Certificate was found (thumbprint {certificate.Thumbprint}), but PfxBlob was null or 0 length.");
+				logger.LogError("Certificate was found (thumbprint {0}), but PfxBlob was null or 0 length.", certificate.Thumbprint);
 				return null;
 			}
 

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -193,11 +193,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 							appTuple.App.Name,
 							domain);
 
-						if (
-							existingBinding == null ||
-							existingBinding.SslState != SslState.SniEnabled ||
-							existingBinding.Thumbprint != azureCertificate.Thumbprint
-						)
+						if (DoesBindingNeedUpdating(existingBinding, azureCertificate.Thumbprint))
 						{
 							logger.LogDebug("Updating host name binding for domain {0}", domain);
 
@@ -220,11 +216,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 							appTuple.Slot.Name,
 							domain);
 
-						if (
-							existingBinding == null ||
-							existingBinding.SslState != SslState.SniEnabled ||
-							existingBinding.Thumbprint != azureCertificate.Thumbprint
-						)
+						if (DoesBindingNeedUpdating(existingBinding, azureCertificate.Thumbprint))
 						{
 							logger.LogDebug("Updating host name binding for domain {0}", domain);
 
@@ -275,6 +267,11 @@ namespace FluffySpoon.LetsEncrypt.Azure
 					}
 				}
 			}
+		}
+
+		private bool DoesBindingNeedUpdating(HostNameBindingInner existingBinding, string certificateThumbprint)
+		{
+			return existingBinding == null || existingBinding.SslState != SslState.SniEnabled || existingBinding.Thumbprint != certificateThumbprint;
 		}
 
 		public async Task<byte[]> RetrieveAsync(PersistenceType persistenceType)

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -71,7 +71,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 
 			var domains = letsEncryptOptions.Domains.ToArray();
 
-			logger.LogInformation("Creating new Azure certificate for key {0} and domains {1}.", persistenceType, String.Join(", ", domains));
+			logger.LogInformation("Creating new Azure certificate for key {0} and domains {1}.", persistenceType, domains);
 
 			var apps = await client.WebApps.ListByResourceGroupAsync(azureOptions.ResourceGroupName);
 
@@ -80,7 +80,7 @@ namespace FluffySpoon.LetsEncrypt.Azure
 			var relevantApps = new HashSet<(IWebApp App, IDeploymentSlot Slot)>();
 			foreach (var app in apps)
 			{
-				logger.LogTrace("Checking hostnames of app {0} ({1}) against domains {2}.", app.Name, app.HostNames, String.Join(", ", domains));
+				logger.LogTrace("Checking hostnames of app {0} ({1}) against domains {2}.", app.Name, app.HostNames, domains);
 
 				if (azureOptions.Slot == null)
 				{


### PR DESCRIPTION
There is an issue where the Azure persistence strategy cannot retrieve the certificate PFX binary data via the fluent management API because PfxBlob is always null. This can result in a new certificate order every time the application is started if Azure is the only site certificate persistence strategy in use. 

This patch fixes the issue by using the certificate store mechanism (X509Store) to retrieve the full raw PFX data.

Also:
* Fixed error in formatting of domains array in logging
* Added conditions to reduce unnecessary updates of hostname bindings