### PR TITLE
Fix file-based persistence for challenges.

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/RegistrationExtensions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/RegistrationExtensions.cs
@@ -92,7 +92,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt
 		  this IServiceCollection services,
 		  string relativeFilePath = "FluffySpoonAspNetLetsEncryptChallenge")
 		{
-			AddFluffySpoonLetsEncryptCertificatePersistence(services,
+			AddFluffySpoonLetsEncryptChallengePersistence(services,
 				new FilePersistenceStrategy(relativeFilePath));
 		}
 


### PR DESCRIPTION
The `AddFluffySpoonLetsEncryptFileChallengePersistence()` extension accidentally stored the challenge in the cert file, rather than a challenge file. 

Fixes #7