### PR TITLE
Remove allocations from the hot path of the middleware

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptChallengeApprovalMiddleware.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptChallengeApprovalMiddleware.cs
@@ -6,29 +6,29 @@ using Microsoft.Extensions.Logging;
 
 namespace FluffySpoon.AspNet.LetsEncrypt
 {
-	public class LetsEncryptChallengeApprovalMiddleware : ILetsEncryptChallengeApprovalMiddleware
-	{
+    public class LetsEncryptChallengeApprovalMiddleware : ILetsEncryptChallengeApprovalMiddleware
+    {
         private const string MagicPrefix = "/.well-known/acme-challenge/";
 
         private readonly RequestDelegate _next;
-		private readonly ILogger<ILetsEncryptChallengeApprovalMiddleware> _logger;
-		private readonly IPersistenceService _persistenceService;
+        private readonly ILogger<ILetsEncryptChallengeApprovalMiddleware> _logger;
+        private readonly IPersistenceService _persistenceService;
 
-		public LetsEncryptChallengeApprovalMiddleware(
-			RequestDelegate next,
-			ILogger<ILetsEncryptChallengeApprovalMiddleware> logger,
-			IPersistenceService persistenceService)
-		{
-			_next = next;
-			_logger = logger;
-			_persistenceService = persistenceService;
-		}
+        public LetsEncryptChallengeApprovalMiddleware(
+            RequestDelegate next,
+            ILogger<ILetsEncryptChallengeApprovalMiddleware> logger,
+            IPersistenceService persistenceService)
+        {
+            _next = next;
+            _logger = logger;
+            _persistenceService = persistenceService;
+        }
 
         public Task InvokeAsync(HttpContext context)
-		{
+        {
             var path = context.Request.Path;
             if (path.HasValue && path.Value.StartsWith(MagicPrefix))
-			{
+            {
                 return ProcessAcmeChallenge(context);
             }
 


### PR DESCRIPTION
I've factored out a method that allocates a state machine on entry to the `ProcessAcmeChallenge` and removed string allocations from the hot path.

AcmeChallenge middleware would usually handle 99.99+% of the requests hitting the web application, so it makes a lot of sense to invest in optimizing it as much as possible.

This PR aims at reducing allocations to zero for most of the requests hitting a web server. And would allow any allocation only when they make sense.