### PR TITLE
Added content type and content length headers for acme responses

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptChallengeApprovalMiddleware.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/LetsEncryptChallengeApprovalMiddleware.cs
@@ -49,7 +49,12 @@ namespace FluffySpoon.AspNet.LetsEncrypt
                 return;
             }
 
-            await context.Response.WriteAsync(matchingChallenge.Response);
+            // token response is always in ASCII so char count would be equal to byte count here
+            context.Response.ContentLength = matchingChallenge.Response.Length;
+            context.Response.ContentType = "application/octet-stream";
+            await context.Response.WriteAsync(
+                text: matchingChallenge.Response,
+                cancellationToken: context.RequestAborted);
         }
     }
 }


### PR DESCRIPTION
This is a tiny fix that will bring acme response to a standard format and will disable the chunked transfer of the challenge body.