### PR TITLE
LetsEncryptChallengeApprovalMiddleware not processing

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptChallengeApprovalMiddleware.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptChallengeApprovalMiddleware.cs
@@ -8,7 +8,9 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 {
     public class LetsEncryptChallengeApprovalMiddleware : ILetsEncryptChallengeApprovalMiddleware
     {
-        private static readonly PathString MagicPrefix = new PathString("/.well-known/acme-challenge/");
+
+        private const string MagicPrefix = "/.well-known/acme-challenge";
+        private static readonly PathString MagicPrefixSegments = new PathString(MagicPrefix);
 
         private readonly RequestDelegate _next;
         private readonly ILogger<ILetsEncryptChallengeApprovalMiddleware> _logger;
@@ -26,7 +28,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 
         public Task InvokeAsync(HttpContext context)
         {
-            if (context.Request.Path.StartsWithSegments(MagicPrefix))
+            if (context.Request.Path.StartsWithSegments(MagicPrefixSegments))
             {
                 return ProcessAcmeChallenge(context);
             }
@@ -39,7 +41,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
             var path = context.Request.Path.ToString();
             _logger.LogDebug("Challenge invoked: {challengePath}", path);
 
-            var requestedToken = path.Substring(MagicPrefix.Value.Length);
+            var requestedToken = path.Substring($"{MagicPrefix}/".Length);
             var allChallenges = await _persistenceService.GetPersistedChallengesAsync();
             var matchingChallenge = allChallenges.FirstOrDefault(x => x.Token == requestedToken);
             if (matchingChallenge == null)


### PR DESCRIPTION
MagicPrefix has an ending slash, which results in the expression evaluating to false.
https://github.com/ffMathy/FluffySpoon.AspNet.LetsEncrypt/issues/28