### PR TITLE
Preload intermediate certificates before exposing certificate to Kestrel

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
@@ -20,6 +20,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 		private readonly LetsEncryptOptions _options;
 
 		private Timer _timer;
+		private X509Chain _chain;
 
 		public LetsEncryptRenewalService(
 			ICertificateProvider certificateProvider,
@@ -76,7 +77,34 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 			try
 			{
 				var result = await _certificateProvider.RenewCertificateIfNeeded(Certificate);
+				
+				var chain = new X509Chain
+				{
+					ChainPolicy =
+					{
+						VerificationFlags = X509VerificationFlags.AllFlags,
+						RevocationFlag = X509RevocationFlag.ExcludeRoot,
+						RevocationMode = X509RevocationMode.NoCheck
+					}
+				};
+            
+				if (chain.Build(result.Certificate))
+				{
+					_logger.LogInformation("Successfully built certificate chain");
+
+					var oldChain = Interlocked.Exchange(ref _chain, chain);
+					oldChain?.Dispose();
+				}
+				else
+				{
+					// todo: wording
+					// todo: throw?
+					_logger.LogWarning("Was not able to build certificate chain");
+					chain.Dispose();
+				}
+				
 				Certificate = result.Certificate;
+				// todo: dispose old cert?
 				
 				if (result.Status == Renewed)
 				{
@@ -117,6 +145,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 
 		public void Dispose()
 		{
+			_chain?.Dispose();
 			_timer?.Dispose();
 		}
 	}


### PR DESCRIPTION
I had quite an epic issue with certificate verification in .net core.

Full details here: https://github.com/dotnet/aspnetcore/issues/21183

TLDR: .net core 3.1 will perform an HTTP call to root authority of the certificate issuer to check if it was revoked. If this happens under load after a restart, threadpool is filled with blocking calls to check cert revocation, rendering app unresponsive.


@davidfowl suggested a workaround that can prevent this behavior. 

There are several open questions marked as todo's in code





