### PR TITLE
Allow first run of the renewal service to be delayed

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptOptions.cs
@@ -50,5 +50,12 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 		/// Gets or sets the <see cref="Certes.KeyAlgorithm"/> used to request a new LetsEncrypt certificate.
 		/// </summary>
 		public KeyAlgorithm KeyAlgorithm { get; set; } = KeyAlgorithm.ES256;
-    }
+
+		/// <summary>
+		/// Get or set a delay before the initial run of the renewal service (subsequent runs will be at 1hr intervals)
+		/// On some platform/deployment systems (e.g Azure Slot Swap) we do not want the renewal service to start immediately, because we may not
+		/// yet have incoming requests (e.g. for challenges) directed to us. 
+		/// </summary>
+		public TimeSpan RenewalServiceStartupDelay { get; set; } = TimeSpan.Zero;
+	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
@@ -134,7 +134,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 
 		private void OnApplicationStarted(CancellationToken t) {
 			_logger.LogInformation("Application started");
-			_timer?.Change(TimeSpan.Zero, TimeSpan.FromHours(1));
+			_timer?.Change(_options.RenewalServiceStartupDelay, TimeSpan.FromHours(1));
 		}
 
 		public void Dispose()


### PR DESCRIPTION
This PR is to fix a very hard-to-diagnose problem which occurs with certain types of deployment (notably Azure App Service slot swapping) which uses the following sequence to upgrade a running service:

1. New instance of application is started up while existing instance is still running
2. New instance is warmed up and verified to be receiving traffic
3. Once new instance is running, traffic is switched from old instance to new instance
4. Old instance is shut down

This creates a problem for the first run of the renewal service when using memory persistence for storing challenges, because that first run happens during step '2' above - i.e. the new application is running OK, but it does't receive the challenges because they go to the old app.
(It might also happen with file persistence, because the old and new instances are not necessarily seeing the same filesystem).

This fix is just a very simple means to delay the first cycle for a short while, until the traffic has been switched to the new app instance.   The default is still zero, so this doesn't need to affect anyone who doesn't need this feature.

Not that this is not simply a matter of 'waiting until the app is ready to serve requests' - the new app *is* ready to serve requests, it's just that the platform load-balancer is not delivering them to the new app yet.

This was very hard to diagnose because both old and new servers are labelled 'production' so their logs are indistinguishable merged in Seq - so I could see the challenge get persisted (on the new application) but it's not there when the challenge is received (on the old application).