### PR TITLE
More detailed logging

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptChallengeApprovalMiddleware.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptChallengeApprovalMiddleware.cs
@@ -39,7 +39,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
         private async Task ProcessAcmeChallenge(HttpContext context)
         {
             var path = context.Request.Path.ToString();
-            _logger.LogDebug("Challenge invoked: {challengePath}", path);
+            _logger.LogDebug("Challenge invoked: {challengePath} by {IpAddress}", path, context.Connection.RemoteIpAddress);
 
             var requestedToken = path.Substring($"{MagicPrefix}/".Length);
             var allChallenges = await _persistenceService.GetPersistedChallengesAsync();

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptClient.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptClient.cs
@@ -33,9 +33,11 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 
         public async Task<PlacedOrder> PlaceOrder(string[] domains)
         {
-            _logger.LogInformation("Ordering LetsEncrypt certificate for domains {0}.", new object[] { domains });
+            _logger.LogInformation("Ordering LetsEncrypt certificate for domains {Domains}.", (object)domains);
             var order = await _acme.NewOrder(domains);
+
             var allAuthorizations = await order.Authorizations();
+
             var challengeContexts = await Task.WhenAll(allAuthorizations.Select(x => x.Http()));
             var nonNullChallengeContexts = challengeContexts.Where(x => x != null).ToArray();
             
@@ -45,6 +47,8 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
                 Response = x.KeyAuthz,
                 Domains = domains
             }).ToArray();
+            
+            _logger.LogTrace("LetsEncrypt placed order for domains {Domains} with challenges {Challenges}", domains, dtos);
             
             return new PlacedOrder(dtos, order, nonNullChallengeContexts);
         }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptClientFactory.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptClientFactory.cs
@@ -51,7 +51,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
             }
             else
             {
-                _logger.LogDebug("Creating LetsEncrypt account with email {0}.", _options.Email);
+                _logger.LogDebug("Creating LetsEncrypt account with email {EmailAddress}.", _options.Email);
                 var acme = new AcmeContext(_options.LetsEncryptUri);
                 await acme.NewAccount(_options.Email, true);
                 await _persistenceService.PersistAccountCertificateAsync(acme.AccountKey);

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certes/LetsEncryptRenewalService.cs
@@ -49,6 +49,8 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 					" which means that the LetsEncrypt certificate will never renew.");
 			}
 
+			_logger.LogTrace("LetsEncryptRenewalService StartAsync");
+
 			_lifetime.ApplicationStarted.Register(() => OnApplicationStarted(cancellationToken));
 
 			foreach (var lifecycleHook in _lifecycleHooks)
@@ -122,10 +124,11 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 		private async Task RunOnceWithErrorHandlingAsync()
 		{
 			try {
+				_logger.LogTrace("LetsEncryptRenewalService - timer callback starting");
 				await RunOnceAsync();
 				_timer?.Change(TimeSpan.FromHours(1), TimeSpan.FromHours(1));
 			} catch (Exception e) when (_options.RenewalFailMode != RenewalFailMode.Unhandled) {
-				_logger.LogWarning(e, $"Exception occured renewing certificates: '{e.Message}.'");
+				_logger.LogWarning(e, "Exception occurred renewing certificates: '{Message}'", e.Message);
 				if (_options.RenewalFailMode == RenewalFailMode.LogAndRetry) {
 					_timer?.Change(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
 				}
@@ -133,7 +136,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certes
 		}
 
 		private void OnApplicationStarted(CancellationToken t) {
-			_logger.LogInformation("Application started");
+			_logger.LogInformation("LetsEncryptRenewalService - Application started");
 			_timer?.Change(TimeSpan.Zero, TimeSpan.FromHours(1));
 		}
 

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateProvider.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateProvider.cs
@@ -52,7 +52,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
             var persistedSiteCertificate = await _persistenceService.GetPersistedSiteCertificateAsync();
             if (_certificateValidator.IsCertificateValid(persistedSiteCertificate))
             {
-                _logger.LogInformation("A persisted non-expired LetsEncrypt certificate was found and will be used.");
+                _logger.LogInformation("A persisted non-expired LetsEncrypt certificate was found and will be used: {Thumbprint}", persistedSiteCertificate.Thumbprint);
                 return new CertificateRenewalResult(persistedSiteCertificate, CertificateRenewalStatus.LoadedFromStore);
             }
 			

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateValidator.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateValidator.cs
@@ -32,6 +32,9 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
                     return false;
                 
                 var now = DateTime.Now;
+
+                _logger.LogTrace("Validating cert UntilExpiry {UntilExpiry}, AfterIssue {AfterIssue} - {Certificate}",
+                    _options.TimeUntilExpiryBeforeRenewal, _options.TimeAfterIssueDateBeforeRenewal, certificate);
                     
                 if (_options.TimeUntilExpiryBeforeRenewal != null && certificate.NotAfter - now < _options.TimeUntilExpiryBeforeRenewal)
                     return false;

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/ChallengeDto.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/ChallengeDto.cs
@@ -5,5 +5,10 @@
 		public string Token { get; set; }
 		public string Response { get; set; }
 		public string[] Domains { get; set; }
+
+		public override string ToString()
+		{
+			return $"Token: {Token}";
+		}
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryChallengePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryChallengePersistenceStrategy.cs
@@ -34,5 +34,10 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 		{
 			return Task.FromResult(_challenges);
 		}
+
+		public override string ToString()
+		{
+			return $"MemoryChallengePersistence: Content {string.Join(",", _challenges)}";
+		}
 	}
 }


### PR DESCRIPTION
Fixes #72

An effort has been made to avoid lots of additional allocation/processing (e.g. `string.join`) other than in cases where there is already a problem which needs notification.
Efforts in the AzurePersistence module are light, because there's going to have some more major work done on it