### PR TITLE
New update mechanism for Azure certs

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppInstance.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppInstance.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.AppService.Fluent;
+using Microsoft.Azure.Management.AppService.Fluent.Models;
+using Microsoft.Azure.Management.Fluent;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Azure
+{
+    /// <summary>
+    /// A reference to an Azure app, which might be either a simple app, or a deployment slot
+    /// </summary>
+    public class AzureAppInstance
+    {
+        readonly IWebApp _app;
+        readonly IDeploymentSlot _slot;
+
+        public AzureAppInstance(IWebApp app)
+        {
+            _app = app;
+        }
+
+        public AzureAppInstance(IWebApp app, IDeploymentSlot slot)
+        {
+            _app = app;
+            _slot = slot;
+        }
+        
+        /// <summary>
+        /// A general purpose name for this instance
+        /// </summary>
+        public string DisplayName => IsSlot ? $"{_app.Name}/{_slot.Name}" : _app.Name;
+
+        /// <summary>
+        /// Get the host names associated with this instance
+        /// </summary>
+        public ISet<string> HostNames => IsSlot ? _slot.HostNames : _app.HostNames;
+
+        private bool IsSlot => _slot != null;
+
+        public Task<HostNameBindingInner> GetHostNameBindingAsync(IAzure client, string resourceGroupName, string domain)
+        {
+            if (IsSlot)
+            {
+                return client.WebApps.Inner.GetHostNameBindingSlotAsync(resourceGroupName,
+                    _app.Name,
+                    _slot.Name,
+                    domain);
+            }
+            else
+            {
+                return client.WebApps.Inner.GetHostNameBindingAsync(resourceGroupName,
+                    _app.Name,
+                    domain);
+            }
+        }
+        
+        public Task SetHostNameBindingAsync(IAzure client, string resourceGroupName, string domain, HostNameBindingInner binding)
+        {
+            if (IsSlot)
+            {
+                return client.WebApps.Inner.CreateOrUpdateHostNameBindingSlotWithHttpMessagesAsync(
+                    resourceGroupName,
+                    _app.Name,
+                    domain,
+                    binding,
+                    _slot.Name);
+            }
+            else
+            {
+                return client.WebApps.Inner.CreateOrUpdateHostNameBindingWithHttpMessagesAsync(
+                    resourceGroupName,
+                    _app.Name,
+                    domain,
+                    binding
+                );
+            }
+        }
+
+        public Task<IReadOnlyDictionary<string, IAppSetting>> GetAppSettings()
+        {
+            if (IsSlot)
+            {
+                return _slot.GetAppSettingsAsync();
+            }
+            else
+            {
+                return _app.GetAppSettingsAsync();
+            }
+        }
+
+        public Task UpdateAppSettingAsync(string key, string value)
+        {
+            if (IsSlot)
+            {
+                return _slot.Update()
+                    .WithAppSetting(key, value)
+                    .ApplyAsync();
+            }
+            else
+            {
+                return _app.Update()
+                    .WithAppSetting(key, value)
+                    .ApplyAsync();
+            }
+        }
+        
+        public string RegionName => IsSlot ? _slot.RegionName : _app.RegionName;
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -20,11 +20,11 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 		private const string WildcardPrefix = "*.";
 		private const string AzureCertThumbprintsAppSettingName = "WEBSITE_LOAD_CERTIFICATES";
 
-		private readonly AzureOptions azureOptions;
-		private readonly LetsEncryptOptions letsEncryptOptions;
+		private readonly AzureOptions _azureOptions;
+		private readonly LetsEncryptOptions _letsEncryptOptions;
 
-		private readonly ILogger<IAzureAppServiceSslBindingCertificatePersistenceStrategy> logger;
-		private readonly IAzure client;
+		private readonly ILogger<IAzureAppServiceSslBindingCertificatePersistenceStrategy> _logger;
+		private readonly IAzure _client;
 
 		private string TagName
 		{
@@ -32,7 +32,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 			{
 				const string prefix = "FluffySpoonAspNetLetsEncrypt";
 
-				var domainsTag = letsEncryptOptions
+				var domainsTag = _letsEncryptOptions
 					.Domains
 					.Aggregate(string.Empty, (a, b) => a + "," + b);
 				return prefix + "_" + domainsTag;
@@ -44,16 +44,16 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 			LetsEncryptOptions letsEncryptOptions,
 			ILogger<IAzureAppServiceSslBindingCertificatePersistenceStrategy> logger)
 		{
-			this.azureOptions = azureOptions;
-			this.letsEncryptOptions = letsEncryptOptions;
-			this.logger = logger;
+			_azureOptions = azureOptions;
+			_letsEncryptOptions = letsEncryptOptions;
+			_logger = logger;
 
-			client = Authenticate();
+			_client = Authenticate();
 		}
 
 		private IAzure Authenticate()
 		{
-			return Azure.Authenticate(azureOptions.Credentials).WithDefaultSubscription();
+			return Azure.Authenticate(_azureOptions.Credentials).WithDefaultSubscription();
 		}
 
 		private bool DoesDomainMatch(string boundDomain, string certificateDomain) {
@@ -90,274 +90,332 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 		{
 			if (bytes.Length == 0)
 			{
-				logger.LogWarning("Tried to persist empty certificate.");
+				_logger.LogWarning("Tried to persist empty certificate.");
 				return;
 			}
 
 			if (persistenceType != CertificateType.Site)
 			{
-				logger.LogTrace("Skipping certificate persistence because a certificate of type {0} can't be persisted in Azure.", persistenceType);
+				_logger.LogTrace("Skipping certificate persistence because a certificate of type {CertificateType} can't be persisted in Azure.", persistenceType);
 				return;
 			}
 
-			var domains = letsEncryptOptions.Domains.ToArray();
+			var domains = _letsEncryptOptions.Domains.ToArray();
 
-			logger.LogInformation("Creating new Azure certificate for key {0} and domains {1}.", persistenceType, String.Join(", ", domains));
+			_logger.LogInformation("Creating new Azure certificate of type {CertificateType} and domains {DomainNames}.", persistenceType, String.Join(", ", domains));
 
-			var apps = await client.WebApps.ListByResourceGroupAsync(azureOptions.ResourceGroupName);
+			var apps = await _client.WebApps.ListByResourceGroupAsync(_azureOptions.ResourceGroupName);
 
-			string regionName = null;
-
-			var relevantApps = new HashSet<(IWebApp App, IDeploymentSlot Slot)>();
+			var relevantApps = new HashSet<AzureAppInstance>();
 			foreach (var app in apps)
 			{
-				logger.LogTrace("Checking hostnames of app {0} ({1}) against domains {2}.", app.Name, app.HostNames, String.Join(", ", domains));
+				_logger.LogTrace("Checking hostnames of app {AppName} (AppHostNames: {HostNames}) against domains {DomainNames}.", app.Name, app.HostNames, String.Join(", ", domains));
 
-				if (azureOptions.Slot == null)
+				if (DoDomainsMatch(app.HostNames, domains))
 				{
-					if (!DoDomainsMatch(app.HostNames, domains))
-						continue;
+					_logger.LogTrace("App {AppName} matches a domain", app.Name);
 
-					relevantApps.Add((app, null));
+					relevantApps.Add(new AzureAppInstance(app));
 				}
-				else
-				{
-					var slots = app.DeploymentSlots
-						.List()
-						.Where(x => DoDomainsMatch(x.HostNames, domains));
 
-					if (!slots.Any())
-						continue;
+				if (app.DeploymentSlots != null)
+				{
+					var slots = await app.DeploymentSlots.ListAsync();
 
 					foreach (var slot in slots)
-						relevantApps.Add((app, slot));
+					{
+						_logger.LogTrace(
+							"Checking hostnames of app {AppName}/slot {slot} (AppHostNames: {HostNames}) against domains {Domains}.",
+							app.Name, slot.Name,
+							slot.HostNames, String.Join(", ", domains));
+
+						if (DoDomainsMatch(slot.HostNames, domains))
+						{
+							_logger.LogTrace("App {AppName}/slot {slot} matches a domain", app.Name, slot.Name);
+
+							relevantApps.Add(new AzureAppInstance(app, slot));
+						}
+					}
 				}
-
-				regionName = app.RegionName;
 			}
+			
+			if (!relevantApps.Any())
+				throw new InvalidOperationException(
+					$"Could not find an app that has a hostname created for domains {String.Join(", ", domains)}.");
 
-			if (regionName == null)
-				throw new InvalidOperationException("Could not find an app that has a hostname created for domains " + String.Join(", ", domains) + ".");
+			var regionName = relevantApps.FirstOrDefault()?.RegionName;
+		
+			_logger.LogInformation("Found region name to use to use for new certificate: {RegionName}", regionName);
 
-			var azureCertificate = await GetExistingAzureCertificateAsync(persistenceType);
-			if (azureCertificate != null)
-			{
-				logger.LogInformation("Updating existing Azure certificate for key {0}.", persistenceType);
-				await client.WebApps.Manager
-					.AppServiceCertificates
-					.Inner
-					.UpdateAsync(
-						azureOptions.ResourceGroupName,
-						azureCertificate.Name,
-						new CertificatePatchResource()
-						{
-							Password = nameof(FluffySpoon),
-							HostNames = domains,
-							PfxBlob = bytes
-						});
-				azureCertificate = await GetExistingAzureCertificateAsync(persistenceType);
-			}
-			else
-			{
-				logger.LogInformation("Found region name to use: {0}.", regionName);
-
-				var certificateName = TagName + "_" + Guid.NewGuid();
-				azureCertificate = await client.WebApps.Manager
-					.AppServiceCertificates
-					.Define(certificateName)
-					.WithRegion(regionName)
-					.WithExistingResourceGroup(azureOptions.ResourceGroupName)
-					.WithPfxByteArray(bytes)
-					.WithPfxPassword(nameof(FluffySpoon))
-					.CreateAsync();
-
-				var tags = new Dictionary<string, string>();
-				foreach (var tag in azureCertificate.Tags)
-					tags.Add(tag.Key, tag.Value);
-
-				tags.Add(TagName, GetTagValue(persistenceType));
-
-				logger.LogInformation("Updating tags: {0}.", tags);
-
-				await client.WebApps.Manager
-					.AppServiceCertificates
-					.Inner
-					.UpdateAsync(
-						azureOptions.ResourceGroupName,
-						azureCertificate.Name,
-						new CertificatePatchResource()
-						{
-							Tags = tags
-						});
-			}
+			IAppServiceCertificate newCertificate = await CreateOrUpdateCertificateAsync(bytes, regionName);
 
 			foreach (var appTuple in relevantApps)
 			{
-				string[] domainsToUpgrade;
-				if (azureOptions.Slot == null)
+				await UpdateSingleApp(appTuple, newCertificate, domains);
+			}
+
+			await DeleteOldCertificatesAsync(newCertificate);
+		}
+
+		/// <summary>
+		/// If we've had to replace an existing certificate, then we'll need to delete the old one
+		/// We actually delete any matching certificate created by FluffySpoon which ISN'T the one we
+		/// just created
+		/// </summary>
+		/// <returns></returns>
+		private async Task DeleteOldCertificatesAsync(IAppServiceCertificate newCertificate)
+		{
+			foreach (var certificate in await GetExistingAzureCertificatesAsync(CertificateType.Site))
+			{
+				if (certificate.Thumbprint != newCertificate.Thumbprint)
 				{
-					logger.LogInformation("Checking host name bindings for app {0}", appTuple.App.Name);
-					domainsToUpgrade = appTuple
-						.App
-						.HostNames
-						.Where(boundDomain => DoesDomainMatch(boundDomain, domains))
-						.ToArray();
-				}
-				else
-				{
-					logger.LogInformation("Checking host name bindings for app {0}/{1}", appTuple.App.Name, appTuple.Slot.Name);
-					domainsToUpgrade = appTuple
-						.Slot
-						.HostNames
-						.Where(boundDomain => DoesDomainMatch(boundDomain, domains))
-						.ToArray();
-				}
+					_logger.LogInformation("Deleting old Azure certificate {CertificateName}", certificate.Name);
 
-				foreach (var domain in domainsToUpgrade)
-				{
-					logger.LogDebug("Checking host name binding for domain {0}", domain);
-
-					if (azureOptions.Slot == null)
-					{
-						var existingBinding = await client.WebApps.Inner.GetHostNameBindingAsync(azureOptions.ResourceGroupName,
-							appTuple.App.Name,
-							domain);
-
-						if (DoesBindingNeedUpdating(existingBinding, azureCertificate.Thumbprint))
-						{
-							logger.LogDebug("Updating host name binding for domain {0}", domain);
-
-							await client.WebApps.Inner.CreateOrUpdateHostNameBindingWithHttpMessagesAsync(
-								azureOptions.ResourceGroupName,
-								appTuple.App.Name,
-								domain,
-								new HostNameBindingInner(
-									azureResourceType: AzureResourceType.Website,
-									hostNameType: HostNameType.Verified,
-									customHostNameDnsRecordType: CustomHostNameDnsRecordType.CName,
-									sslState: SslState.SniEnabled,
-									thumbprint: azureCertificate.Thumbprint));
-						}
-					}
-					else
-					{
-						var existingBinding = await client.WebApps.Inner.GetHostNameBindingSlotAsync(azureOptions.ResourceGroupName,
-							appTuple.App.Name,
-							appTuple.Slot.Name,
-							domain);
-
-						if (DoesBindingNeedUpdating(existingBinding, azureCertificate.Thumbprint))
-						{
-							logger.LogDebug("Updating host name binding for domain {0}", domain);
-
-							await client.WebApps.Inner.CreateOrUpdateHostNameBindingSlotWithHttpMessagesAsync(
-							azureOptions.ResourceGroupName,
-							appTuple.App.Name,
-							domain,
-							new HostNameBindingInner(
-								azureResourceType: AzureResourceType.Website,
-								hostNameType: HostNameType.Verified,
-								customHostNameDnsRecordType: CustomHostNameDnsRecordType.CName,
-								sslState: SslState.SniEnabled,
-								thumbprint: azureCertificate.Thumbprint),
-							appTuple.Slot.Name);
-						}
-					}
-				}
-
-				logger.LogDebug("Getting app settings");
-
-				var appSettings = await client.WebApps.Manager
-					.WebApps
-					.GetByResourceGroup(appTuple.App.ResourceGroupName, appTuple.App.Name)
-					.GetAppSettingsAsync();
-
-				var loadCertificatesSetting = appSettings.ContainsKey(AzureCertThumbprintsAppSettingName) ? appSettings[AzureCertThumbprintsAppSettingName].Value : String.Empty;
-				var certThumbprintsToLoad = loadCertificatesSetting.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
-				if (!certThumbprintsToLoad.Contains(azureCertificate.Thumbprint))
-				{
-					logger.LogInformation("Adding certificate thumbprint {0} to {1} app setting", azureCertificate.Thumbprint, AzureCertThumbprintsAppSettingName);
-
-					certThumbprintsToLoad.Add(azureCertificate.Thumbprint);
-
-					loadCertificatesSetting = String.Join(",", certThumbprintsToLoad);
-
-					try
-					{
-						await client.WebApps.Manager
-							.WebApps
-							.GetByResourceGroup(appTuple.App.ResourceGroupName, appTuple.App.Name)
-							.Update()
-							.WithAppSetting(AzureCertThumbprintsAppSettingName, loadCertificatesSetting)
-							.ApplyAsync();
-					}
-					catch (Exception ex)
-					{
-						logger.LogError(ex, "Error updating app settings for {0}", appTuple.App.Name);
-					}
+					await _client.WebApps.Manager
+						.AppServiceCertificates
+						.Inner
+						.DeleteAsync(
+							_azureOptions.ResourceGroupName,
+							certificate.Name);
 				}
 			}
 		}
 
+		private async Task<IAppServiceCertificate> CreateOrUpdateCertificateAsync(byte[] bytes, string regionName)
+		{
+			var azureCertificate = await GetExistingAzureCertificateAsync(CertificateType.Site);
+			if (azureCertificate != null)
+			{
+				return await UpdateExistingCertificateAsync(azureCertificate, bytes);
+			}
+			else
+			{
+				return await CreateNewCertificateAsync(bytes, regionName);
+			}
+		}
+
+		/// <summary>
+		/// Update an existing certificate
+		/// </summary>
+		private async Task<IAppServiceCertificate> UpdateExistingCertificateAsync(IAppServiceCertificate existingCertificate, byte[] bytes)
+		{
+			_logger.LogInformation("Updating existing Azure certificate name {CertificateName}.", existingCertificate.Name);
+			
+			// Azure doesn't let us update a certificate which is bound (the api fails with 409 Conflict), and we can't
+			// unbind the running certificate without causing problems for a running site
+			// So we will need to create a new certificate, bind to that, and then delete the existing one
+			return await CreateNewCertificateAsync(bytes, existingCertificate.RegionName);
+		}
+
+		/// <summary>
+		/// Create a new certificate from scratch
+		/// </summary>
+		private async Task<IAppServiceCertificate> CreateNewCertificateAsync(byte[] bytes, string regionName)
+		{
+			var certificateName = TagName + "_" + Guid.NewGuid();
+			
+			_logger.LogInformation("Creating new Azure certificate with name {CertificateName}", certificateName);
+
+			IAppServiceCertificate azureCertificate = await _client.WebApps.Manager
+				.AppServiceCertificates
+				.Define(certificateName)
+				.WithRegion(regionName)
+				.WithExistingResourceGroup(_azureOptions.ResourceGroupName)
+				.WithPfxByteArray(bytes)
+				.WithPfxPassword(nameof(FluffySpoon))
+				.CreateAsync();
+
+			_logger.LogTrace("Created new Azure certificate with name {CertificateName}", azureCertificate.Name);
+
+			var tags = new Dictionary<string, string>();
+			foreach (var tag in azureCertificate.Tags)
+				tags.Add(tag.Key, tag.Value);
+
+			tags.Add(TagName, GetTagValue(CertificateType.Site));
+
+			_logger.LogInformation("Updating tags: {Tags} on certificate {CertificateName}", tags, azureCertificate.Name);
+
+			await _client.WebApps.Manager
+				.AppServiceCertificates
+				.Inner
+				.UpdateAsync(
+					_azureOptions.ResourceGroupName,
+					azureCertificate.Name,
+					new CertificatePatchResource()
+					{
+						Tags = tags
+					});
+			return azureCertificate;
+		}
+
+		/// <summary>
+		/// Update the bindings and the app settings for a single application instance 
+		/// </summary>
+		private async Task UpdateSingleApp(AzureAppInstance appInstance, 
+			IAppServiceCertificate azureCertificate,
+			string[] domains)
+		{
+			await UpdateAppBindingsAsync(appInstance, azureCertificate, domains);
+
+			await UpdateAppSettingsAsync(appInstance, azureCertificate);
+		}
+
+		private async Task UpdateAppBindingsAsync(AzureAppInstance appInstance, 
+			IAppServiceCertificate azureCertificate, 
+			string[] domains)
+		{
+			_logger.LogInformation("Checking host name bindings for app {AppName}", appInstance.DisplayName);
+
+			string[] domainsToUpgrade = appInstance.HostNames
+				.Where(boundDomain => DoesDomainMatch(boundDomain, domains))
+				.ToArray();
+
+			foreach (var domain in domainsToUpgrade)
+			{
+				_logger.LogDebug("Checking host name binding for domain {DomainName}", domain);
+
+				HostNameBindingInner existingBinding =
+					await appInstance.GetHostNameBindingAsync(_client, _azureOptions.ResourceGroupName, domain);
+
+				if (DoesBindingNeedUpdating(existingBinding, azureCertificate.Thumbprint))
+				{
+					_logger.LogDebug("Updating host name binding for app {AppName} domain {DomainName}",
+						appInstance.DisplayName, domain);
+
+					var newBinding = new HostNameBindingInner(
+						azureResourceType: AzureResourceType.Website,
+						hostNameType: HostNameType.Verified,
+						customHostNameDnsRecordType: CustomHostNameDnsRecordType.CName,
+						sslState: SslState.SniEnabled,
+						thumbprint: azureCertificate.Thumbprint);
+
+					await appInstance.SetHostNameBindingAsync(_client,
+						_azureOptions.ResourceGroupName,
+						domain,
+						newBinding);
+				}
+			}
+		}
+
+		/// <summary>
+		/// In order to be able to use the Windows certificate store mechanism for loading X509 certificates,
+		/// we need to have the certificate thumbprint included in the WEBSITE_LOAD_CERTIFICATES environment variable
+		///
+		/// As it stands, there's possibly a problem with this code never removing thumbprints from this variable
+		/// which may cause some kind of problem eventually.  Maybe we should prune thumbprints out of this
+		/// if they correspond to certificates which are not loaded in Azure at all, though there may be
+		/// all sorts of permission problems there...
+		/// </summary>
+		private async Task UpdateAppSettingsAsync(AzureAppInstance appInstance, IAppServiceCertificate azureCertificate)
+		{
+			_logger.LogDebug("Getting app settings for {Name}", appInstance.DisplayName);
+
+			var appSettings = await appInstance.GetAppSettings(); 
+		
+			var loadCertificatesSetting = appSettings.ContainsKey(AzureCertThumbprintsAppSettingName)
+				? appSettings[AzureCertThumbprintsAppSettingName].Value
+				: String.Empty;
+			var certThumbprintsToLoad =
+				loadCertificatesSetting.Split(new [] {','}, StringSplitOptions.RemoveEmptyEntries).ToList();
+			if (!certThumbprintsToLoad.Contains(azureCertificate.Thumbprint))
+			{
+				_logger.LogInformation("Adding certificate thumbprint {Thumbprint} to app setting name {AppSettingName}",
+					azureCertificate.Thumbprint,
+					AzureCertThumbprintsAppSettingName);
+
+				certThumbprintsToLoad.Add(azureCertificate.Thumbprint);
+
+				loadCertificatesSetting = String.Join(",", certThumbprintsToLoad);
+
+				try
+				{
+					await appInstance.UpdateAppSettingAsync(AzureCertThumbprintsAppSettingName, loadCertificatesSetting);
+				}
+				catch (Exception ex)
+				{
+					_logger.LogError(ex, "Error updating app settings for {Name}", appInstance.DisplayName);
+				}
+			}
+		}
+		
 		private bool DoesBindingNeedUpdating(HostNameBindingInner existingBinding, string certificateThumbprint)
 		{
 			return existingBinding == null || existingBinding.SslState != SslState.SniEnabled || existingBinding.Thumbprint != certificateThumbprint;
 		}
 
-		public async Task<byte[]> RetrieveAsync(CertificateType persistenceType)
+		public async Task<byte[]> RetrieveAsync(CertificateType certificateType)
 		{
-			var certificate = await GetExistingCertificateAsync(persistenceType);
+			var certificate = await GetExistingCertificateAsync(certificateType);
 
 			if (certificate == null)
 			{
-				logger.LogInformation("Certificate of type {0} not found.", persistenceType);
+				_logger.LogInformation("Certificate of type {CertificateType} not found.", certificateType);
 				return null;
 			}
 
-			var pfxBlob = certificate?.GetRawCertData();
+			var pfxBlob = certificate.GetRawCertData();
 
 			if (pfxBlob == null || pfxBlob.Length == 0)
 			{
-				logger.LogError("Certificate was found (thumbprint {0}), but PfxBlob was null or 0 length.", certificate.Thumbprint);
+				_logger.LogError("Certificate was found (thumbprint {Thumbprint}), but PfxBlob was null or 0 length.", certificate.Thumbprint);
 				return null;
 			}
 
 			return pfxBlob;
 		}
 
+		/// <summary>
+		/// Get the existing certificate with the longest available lifetime, or null if we can't find one
+		/// </summary>
 		private async Task<IAppServiceCertificate> GetExistingAzureCertificateAsync(CertificateType certificateType)
 		{
+			return (await GetExistingAzureCertificatesAsync(certificateType)).OrderByDescending(cert => cert.ExpirationDate).FirstOrDefault();
+		}
+		
+		private async Task<IEnumerable<IAppServiceCertificate>> GetExistingAzureCertificatesAsync(CertificateType certificateType)
+		{
+			var result = new List<IAppServiceCertificate>();
+			
 			if (certificateType != CertificateType.Site)
 			{
-				logger.LogTrace("Skipping certificate retrieval of a certificate of type {0}, which can't be persisted in Azure.", certificateType);
-				return null;
+				_logger.LogTrace("Skipping certificate retrieval of a certificate of type {CertificateType}, which can't be persisted in Azure.", certificateType);
+				return result;
 			}
 
-			var certificates = await client.WebApps.Manager
+			var certificates = await _client.WebApps.Manager
 				.AppServiceCertificates
-				.ListByResourceGroupAsync(azureOptions.ResourceGroupName);
-
-			logger.LogInformation("Trying to find existing Azure certificate with key {0}.", certificateType);
+				.ListByResourceGroupAsync(_azureOptions.ResourceGroupName);
 
 			var expectedTagValue = GetTagValue(certificateType);
+
+			_logger.LogInformation("Trying to find existing Azure certificate of type {CertificateType} expected tag {TagName}:{ExpectedTagValue}.", certificateType, TagName, expectedTagValue);
 
 			foreach (var certificate in certificates)
 			{
 				var tags = certificate.Tags;
+				
+				_logger.LogTrace("Considering Azure certificate name {CertificateName}, with tags {Tags}", certificate.Name, tags);
+
 				if (!tags.ContainsKey(TagName) || tags[TagName] != expectedTagValue)
 					continue;
 
-				return certificate;
+				_logger.LogTrace("Matched Azure certificate name {CertificateName}", certificate.Name, tags);
+
+				result.Add(certificate);
 			}
 
-			logger.LogInformation("Could not find existing Azure certificate.");
+			if (!result.Any())
+			{
+				_logger.LogWarning("Could not find any matching Azure certificates.");
+			}
 
-			return null;
+			return result;
 		}
+
 
 		private string GetTagValue(CertificateType certificateType)
 		{
-			if (letsEncryptOptions.UseStaging)
+			if (_letsEncryptOptions.UseStaging)
 				return $"{certificateType}-Staging";
 			else
 				return certificateType.ToString();
@@ -369,12 +427,20 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 
 			if (azureCert == null)
 				return null;
+			
+			_logger.LogTrace("Looking for X509 cert with thumbprint {Thumbprint}", azureCert.Thumbprint);
+
 
 			var certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
 			certStore.Open(OpenFlags.ReadOnly);
 
 			try
 			{
+				foreach (var cert in certStore.Certificates)
+				{
+					_logger.LogTrace("Considering X509 cert {Certificate}", cert);
+				}
+
 				var certCollection = certStore.Certificates.Find(
 											X509FindType.FindByThumbprint,
 											// Replace below with your certificate's thumbprint
@@ -384,6 +450,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 				// Get the first cert with the thumbprint
 				if (certCollection.Count > 0)
 				{
+					_logger.LogTrace("Found X509 cert with correct thumbprint {Thumbprint}", azureCert.Thumbprint);
 					var cert = certCollection[0];
 					return cert;
 				}
@@ -393,7 +460,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 				certStore.Close();
 			}
 
-			logger.LogInformation("Could not find existing Azure certificate.");
+			_logger.LogWarning("Could not load X509Certificate for existing Azure certificate thumbprint {Thumbprint} - does WEBSITE_LOAD_CERTIFICATES correctly contain this thumbprint?", azureCert.Thumbprint);
 
 			return null;
 		}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureOptions.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureOptions.cs
@@ -1,12 +1,15 @@
-﻿using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+﻿using System;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 {
 	public class AzureOptions
 	{
 		public string ResourceGroupName { get; set; }
-		public string Slot { get;set; }
 
 		public AzureCredentials Credentials { get; set; }
+		
+		[Obsolete("This is no longer necessary, all matching apps & slots are automatically included")]
+		public string Slot { get;set; }
 	}
 }


### PR DESCRIPTION
* Fixes problem with trying to update certs which are in use
* Transparently treats slots the same way as normal apps
* Fixes problem with base app settings being changed rather than slot settings
* Refactors very large PersistAsync method into parts

Fixes #73 & #74