### PR TITLE
New storage abstractions

### DIFF
--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureCertificate.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/AzureCertificate.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
+using Microsoft.Azure.Management.AppService.Fluent;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Azure
+{
+    /// <summary>
+    /// The representation of the kind of metadata-only certificate which Azure Appservices can provide via the API
+    /// </summary>
+    public class AzureCertificate : IAbstractCertificate
+    {
+        readonly IAppServiceCertificate _certificate;
+
+        public AzureCertificate(IAppServiceCertificate certificate)
+        {
+            _certificate = certificate;
+        }
+
+        public DateTime NotAfter => _certificate.ExpirationDate;
+        public DateTime NotBefore => _certificate.IssueDate;
+        public string Thumbprint => _certificate.Thumbprint;
+
+        public override string ToString()
+        {
+            return $"Azure-{Thumbprint}: From {NotBefore} until {NotAfter}";
+        }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Azure/IAzureAppServiceSslBindingCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Azure/IAzureAppServiceSslBindingCertificatePersistenceStrategy.cs
@@ -3,9 +3,7 @@ using FluffySpoon.AspNet.LetsEncrypt.Persistence;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Azure
 {
-	public interface IAzureAppServiceSslBindingCertificatePersistenceStrategy
+	public interface IAzureAppServiceSslBindingCertificatePersistenceStrategy : ICertificatePersistenceStrategy
 	{
-		Task PersistAsync(CertificateType persistenceType, byte[] bytes);
-		Task<byte[]> RetrieveAsync(CertificateType persistenceType);
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/CustomPersistenceTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/CustomPersistenceTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Certes;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
+using FluffySpoon.AspNet.LetsEncrypt.Persistence;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Tests
+{
+    [TestClass]
+    public class CustomCertificatePersistence
+    {
+        private ICertificatePersistenceStrategy Strategy { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            byte[] store = null;
+            Strategy = new CustomCertificatePersistenceStrategy(
+                (type, data) =>
+                {
+                    store = data;
+                    return Task.CompletedTask;
+                },
+                (type) => Task.FromResult(store));
+        }
+        
+        [TestMethod]
+        public async Task MissingAccountCertificateReturnsNull()
+        {
+            var retrievedCert = (AccountKeyCertificate)await Strategy.RetrieveAccountCertificateAsync();
+            Assert.IsNull(retrievedCert);
+        }
+
+        [TestMethod]
+        public async Task MissingSiteCertificateReturnsNull()
+        {
+            var retrievedCert = (LetsEncryptX509Certificate)await Strategy.RetrieveSiteCertificateAsync();
+            Assert.IsNull(retrievedCert);
+        }
+
+        [TestMethod]
+        public async Task AccountCertificateRoundTrip()
+        {
+            var testCert = new AccountKeyCertificate(KeyFactory.NewKey(KeyAlgorithm.ES256));KeyFactory.NewKey(KeyAlgorithm.ES256); 
+
+            await Strategy.PersistAsync(CertificateType.Account, testCert);
+
+            var retrievedCert = (AccountKeyCertificate)await Strategy.RetrieveAccountCertificateAsync();
+
+            Assert.AreEqual(testCert.RawData, retrievedCert.RawData);
+        }
+
+        [TestMethod]
+        public async Task SiteCertificateRoundTrip()
+        {
+            var testCert = SelfSignedCertificate.Make(new DateTime(2020, 5, 24), new DateTime(2020, 5, 26));; 
+
+            await Strategy.PersistAsync(CertificateType.Site, testCert);
+
+            var retrievedCert = (LetsEncryptX509Certificate)await Strategy.RetrieveSiteCertificateAsync();
+
+            Assert.AreEqual(testCert.RawData, retrievedCert.RawData);
+        }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/FilePersistenceTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/FilePersistenceTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Certes;
+using FluentAssertions;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
+using FluffySpoon.AspNet.LetsEncrypt.Persistence;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Tests
+{
+    [TestClass]
+    public class FileCertificatePersistence
+    {
+        string _testFolder;
+        private ICertificatePersistenceStrategy Strategy { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _testFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Strategy = new FileCertificatePersistenceStrategy(_testFolder);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (_testFolder != null)
+            {
+                try
+                {
+                    Directory.Delete(_testFolder, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+        
+        [TestMethod]
+        public async Task MissingAccountCertificateReturnsNull()
+        {
+            var retrievedCert = (AccountKeyCertificate)await Strategy.RetrieveAccountCertificateAsync();
+            Assert.IsNull(retrievedCert);
+        }
+
+        [TestMethod]
+        public async Task MissingSiteCertificateReturnsNull()
+        {
+            var retrievedCert = (LetsEncryptX509Certificate)await Strategy.RetrieveSiteCertificateAsync();
+            Assert.IsNull(retrievedCert);
+        }
+
+        [TestMethod]
+        public async Task AccountCertificateRoundTrip()
+        {
+            var testCert = new AccountKeyCertificate(KeyFactory.NewKey(KeyAlgorithm.ES256));KeyFactory.NewKey(KeyAlgorithm.ES256); 
+
+            await Strategy.PersistAsync(CertificateType.Account, testCert);
+
+            var retrievedCert = (AccountKeyCertificate)await Strategy.RetrieveAccountCertificateAsync();
+
+            testCert.RawData.Should().Equal(retrievedCert.RawData);
+        }
+
+        [TestMethod]
+        public async Task SiteCertificateRoundTrip()
+        {
+            var testCert = SelfSignedCertificate.Make(new DateTime(2020, 5, 24), new DateTime(2020, 5, 26));; 
+
+            await Strategy.PersistAsync(CertificateType.Site, testCert);
+
+            var retrievedCert = (LetsEncryptX509Certificate)await Strategy.RetrieveSiteCertificateAsync();
+
+            testCert.RawData.Should().Equal(retrievedCert.RawData);
+        }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/LetsEncryptClientTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/LetsEncryptClientTests.cs
@@ -127,7 +127,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             
             LetsEncryptClient.FinalizeOrder(placedOrder).Returns(Task.FromResult(new PfxCertificate(newCertBytes)));
 
-            IPersistableCertificate newCertificate = new LetsEncryptX509Certificate(newCertBytes);
+            var newCertificate = new LetsEncryptX509Certificate(newCertBytes) as IPersistableCertificate;
             PersistenceService.PersistSiteCertificateAsync(newCertificate).Returns(Task.CompletedTask);
             
             // act

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/LetsEncryptClientTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/LetsEncryptClientTests.cs
@@ -65,11 +65,11 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             Sut = sut;
         }
         
-        private static X509Certificate2 ValidCert { get; } = SelfSignedCertificate.Make(
+        private static IAbstractCertificate ValidCert { get; } = SelfSignedCertificate.Make(
             DateTime.Now, 
             DateTime.Now.AddDays(90));
         
-        private static X509Certificate2 InvalidCert { get; } = SelfSignedCertificate.Make(
+        private static IAbstractCertificate InvalidCert { get; } = SelfSignedCertificate.Make(
             DateTime.Now.Subtract(180.Days()),
             DateTime.Now.Subtract(90.Days()));
 
@@ -127,7 +127,8 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             
             LetsEncryptClient.FinalizeOrder(placedOrder).Returns(Task.FromResult(new PfxCertificate(newCertBytes)));
 
-            PersistenceService.PersistSiteCertificateAsync(newCertBytes).Returns(Task.CompletedTask);
+            IPersistableCertificate newCertificate = new LetsEncryptX509Certificate(newCertBytes);
+            PersistenceService.PersistSiteCertificateAsync(newCertificate).Returns(Task.CompletedTask);
             
             // act
             
@@ -136,7 +137,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             // assert
             
             output.Status.Should().Be(Renewed);
-            output.Certificate.RawData.Should().BeEquivalentTo(newCertBytes);
+            ((LetsEncryptX509Certificate) output.Certificate).RawData.Should().BeEquivalentTo(newCertBytes);
 
             CertificateValidator.Received(1).IsCertificateValid(null);
             await PersistenceService.Received(1).GetPersistedSiteCertificateAsync();
@@ -144,7 +145,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             await LetsEncryptClient.Received(1).PlaceOrder(SeqEq(new[] {"test.com"}));
             await PersistenceService.Received(1).PersistChallengesAsync(dtos);
             await PersistenceService.Received(1).DeleteChallengesAsync(dtos);
-            await PersistenceService.Received(1).PersistSiteCertificateAsync(newCertBytes);
+            await PersistenceService.Received(1).PersistSiteCertificateAsync(newCertificate);
             await PersistenceService.Received(1).PersistChallengesAsync(dtos);
             await LetsEncryptClient.Received(1).FinalizeOrder(placedOrder);
             await LetsEncryptClientFactory.Received(1).GetClient();

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/MiddlewareTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/MiddlewareTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Certes;
 using Certes.Acme;
 using FluffySpoon.AspNet.LetsEncrypt.Certes;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 using FluffySpoon.AspNet.LetsEncrypt.Persistence;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -95,7 +96,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
             var finalizationTimeout = await Task.WhenAny(Task.Delay(10000, _fakeClient.OrderFinalizedCts.Token));
             Assert.IsTrue(finalizationTimeout.IsCanceled, "Fake LE client finalization timed out");
 
-            var appCert = LetsEncryptRenewalService.Certificate.RawData;
+            var appCert = ((LetsEncryptX509Certificate)LetsEncryptRenewalService.Certificate).RawData;
             var fakeCert = FakeLetsEncryptClient.FakeCert.RawData;
             
             Assert.IsTrue(appCert.SequenceEqual(fakeCert), "Certificates do not match");
@@ -103,7 +104,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Tests
         
         private class FakeLetsEncryptClient : ILetsEncryptClient
         {
-            public static readonly X509Certificate2 FakeCert = SelfSignedCertificate.Make(DateTime.Now, DateTime.Now.AddDays(90));
+            public static readonly LetsEncryptX509Certificate FakeCert = SelfSignedCertificate.Make(DateTime.Now, DateTime.Now.AddDays(90));
             
             public CancellationTokenSource OrderPlacedCts { get; }
             public CancellationTokenSource OrderFinalizedCts { get; }

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/PersistenceServiceTests.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/PersistenceServiceTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading.Tasks;
+using Certes;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
+using FluffySpoon.AspNet.LetsEncrypt.Persistence;
+using FluffySpoon.AspNet.LetsEncrypt.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Azure
+{
+    [TestClass]
+    public class PersistenceServiceTests
+    {
+        private IPersistenceService PersistenceService { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            PersistenceService = new PersistenceService(
+                new[] {new MemoryCertificatePersistenceStrategy()},
+                new[] {new MemoryChallengePersistenceStrategy()},
+                NullLogger<IPersistenceService>.Instance);
+        }
+
+        [TestMethod]
+        public async Task MissingAccountCertificateReturnsNull()
+        {
+            Assert.IsNull(await PersistenceService.GetPersistedAccountCertificateAsync());
+        }
+
+        [TestMethod]
+        public async Task MissingSiteCertificateReturnsNull()
+        {
+            Assert.IsNull(await PersistenceService.GetPersistedSiteCertificateAsync());
+        }
+       
+        [TestMethod]
+        public async Task AccountCertificateRoundTrip()
+        {
+            var key = KeyFactory.NewKey(KeyAlgorithm.ES256);
+
+            await PersistenceService.PersistAccountCertificateAsync(key);
+
+            var retrievedKey = await PersistenceService.GetPersistedAccountCertificateAsync();
+            
+            Assert.AreEqual(key.ToPem(), retrievedKey.ToPem());
+        }
+
+        [TestMethod]
+        public async Task SiteCertificateRoundTrip()
+        {
+            var testCert = SelfSignedCertificate.Make(new DateTime(2020, 5, 24), new DateTime(2020, 5, 26));; 
+
+            await PersistenceService.PersistSiteCertificateAsync(testCert);
+
+            var retrievedCert = (LetsEncryptX509Certificate)await PersistenceService.GetPersistedSiteCertificateAsync();
+            
+            Assert.AreEqual(testCert.RawData, retrievedCert.RawData);
+        }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt.Tests/SelfSignedCertificate.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt.Tests/SelfSignedCertificate.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Tests
 {
     public static class SelfSignedCertificate
     {
-        public static X509Certificate2 Make(DateTime from, DateTime to)
+        public static LetsEncryptX509Certificate Make(DateTime from, DateTime to)
         {
             var ecdsa = ECDsa.Create(); // generate asymmetric key pair
             var req = new CertificateRequest("cn=foobar", ecdsa, HashAlgorithmName.SHA256);
-            var cert = req.CreateSelfSigned(@from, to);
-            return cert;
+            var cert = req.CreateSelfSigned(from, to);
+            return new LetsEncryptX509Certificate(cert);
         }
     }
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/AccountKeyCertificate.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/AccountKeyCertificate.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Text;
+using Certes;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
+{
+    /// <summary>
+    /// The type of certificate used to store a Let's Encrypt account key
+    /// </summary>
+    public class AccountKeyCertificate : IPersistableCertificate, IKeyCertificate
+    {
+        public AccountKeyCertificate(IKey key)
+        {
+            Key = key;
+            var text = key.ToPem();
+            RawData = Encoding.UTF8.GetBytes(text);
+        }
+
+        public AccountKeyCertificate(byte[] bytes)
+        {
+            RawData = bytes;
+            var text = Encoding.UTF8.GetString(bytes);
+            Key = KeyFactory.FromPem(text);
+        }
+
+        public DateTime NotAfter => throw new InvalidOperationException("No metadata available for key certificate");
+        public DateTime NotBefore => throw new InvalidOperationException("No metadata available for key certificate");
+        public string Thumbprint => throw new InvalidOperationException("No metadata available for key certificate");
+
+        public byte[] RawData { get; }
+        public IKey Key { get; }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateInterfaces.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateInterfaces.cs
@@ -1,0 +1,20 @@
+﻿using Certes;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
+{
+    /// <summary>
+    /// A certificate which can be persisted as a stream of bytes
+    /// </summary>
+    public interface IPersistableCertificate : IAbstractCertificate
+    {
+        public byte[] RawData { get; }
+    }
+    
+    /// <summary>
+    /// A certificate which can return an IKey
+    /// </summary>
+    public interface IKeyCertificate
+    {
+        IKey Key { get; }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateProvider.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateProvider.cs
@@ -39,7 +39,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
             _logger = logger;
         }
 
-        public async Task<CertificateRenewalResult> RenewCertificateIfNeeded(X509Certificate2 current = null)
+        public async Task<CertificateRenewalResult> RenewCertificateIfNeeded(IAbstractCertificate current = null)
         {
             _logger.LogInformation("Checking to see if in-memory LetsEncrypt certificate needs renewal.");
             if (_certificateValidator.IsCertificateValid(current))
@@ -61,7 +61,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
             return new CertificateRenewalResult(newCertificate, CertificateRenewalStatus.Renewed);
         }
         
-        private async Task<X509Certificate2> RequestNewLetsEncryptCertificate()
+        private async Task<IAbstractCertificate> RequestNewLetsEncryptCertificate()
         {
             var client = await _clientFactory.GetClient();
 
@@ -73,11 +73,11 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
             {
                 var pfxCertificateBytes = await client.FinalizeOrder(placedOrder);
 
-                await _persistenceService.PersistSiteCertificateAsync(pfxCertificateBytes.Bytes);
+                await _persistenceService.PersistSiteCertificateAsync(new LetsEncryptX509Certificate(pfxCertificateBytes.Bytes));
 
                 const string password = nameof(FluffySpoon);
 				
-                return new X509Certificate2(pfxCertificateBytes.Bytes, password);
+                return new LetsEncryptX509Certificate(pfxCertificateBytes.Bytes);
             }
             finally
             {

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateRenewalResult.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateRenewalResult.cs
@@ -1,16 +1,14 @@
-using System.Security.Cryptography.X509Certificates;
-
 namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
 {
     public class CertificateRenewalResult
     {
-        public CertificateRenewalResult(X509Certificate2 certificate, CertificateRenewalStatus status)
+        public CertificateRenewalResult(IAbstractCertificate certificate, CertificateRenewalStatus status)
         {
             Certificate = certificate;
             Status = status;
         }
 
-        public X509Certificate2 Certificate { get; }
+        public IAbstractCertificate Certificate { get; }
         
         public CertificateRenewalStatus Status { get; }
     }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateValidator.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/CertificateValidator.cs
@@ -8,7 +8,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
 {
     public interface ICertificateValidator
     {
-        bool IsCertificateValid(X509Certificate2 certificate);
+        bool IsCertificateValid(IAbstractCertificate certificate);
     }
     
     public class CertificateValidator : ICertificateValidator
@@ -24,7 +24,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
             _logger = logger;
         }
 
-        public bool IsCertificateValid(X509Certificate2 certificate)
+        public bool IsCertificateValid(IAbstractCertificate certificate)
         {
             try
             {

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/IAbstractCertificate.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/IAbstractCertificate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
+{
+    /// <summary>
+    /// The most generic form of certificate, metadata provision only
+    /// </summary>
+    public interface IAbstractCertificate
+    {
+        public DateTime NotAfter { get; }
+        public DateTime NotBefore { get; }
+        string Thumbprint { get; }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/ICertificateProvider.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/ICertificateProvider.cs
@@ -5,6 +5,6 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
 {
     public interface ICertificateProvider
     {
-        Task<CertificateRenewalResult> RenewCertificateIfNeeded(X509Certificate2 current = null);
+        Task<CertificateRenewalResult> RenewCertificateIfNeeded(IAbstractCertificate current = null);
     }
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/LetsEncryptX509Certificate.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Certificates/LetsEncryptX509Certificate.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace FluffySpoon.AspNet.LetsEncrypt.Certificates
+{
+    public class LetsEncryptX509Certificate : IPersistableCertificate
+    {
+        readonly X509Certificate2 _certificate;
+
+        public LetsEncryptX509Certificate(X509Certificate2 certificate)
+        {
+            _certificate = certificate;
+            RawData = certificate.RawData;
+        }
+
+        public LetsEncryptX509Certificate(byte[] data)
+        {
+            _certificate = new X509Certificate2(data, nameof(FluffySpoon));
+            RawData = data;
+        }
+
+        public DateTime NotAfter => _certificate.NotAfter;
+        public DateTime NotBefore => _certificate.NotBefore;
+        public string Thumbprint => _certificate.Thumbprint;
+        public X509Certificate2 GetCertificate() => _certificate;
+        public byte[] RawData { get; }
+
+        public override string ToString()
+        {
+            return _certificate.ToString();
+        }
+    }
+}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/KestrelOptionsSetup.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/KestrelOptionsSetup.cs
@@ -28,7 +28,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt
                     o.ServerCertificateSelector = (_a, _b) => x509Certificate.GetCertificate();
                 });
             }
-            else
+            else if(LetsEncryptRenewalService.Certificate != null)
             {
                 _logger.LogError("This certificate cannot be used with Kestrel");
             }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/KestrelOptionsSetup.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/KestrelOptionsSetup.cs
@@ -2,19 +2,36 @@
 using System.Collections.Generic;
 using System.Text;
 using FluffySpoon.AspNet.LetsEncrypt.Certes;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
+using FluffySpoon.AspNet.LetsEncrypt.Persistence;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace FluffySpoon.AspNet.LetsEncrypt
 {
     internal class KestrelOptionsSetup : IConfigureOptions<KestrelServerOptions>
     {
+        readonly ILogger<KestrelOptionsSetup> _logger;
+
+        public KestrelOptionsSetup(ILogger<KestrelOptionsSetup> logger)
+        {
+            _logger = logger;
+        }
+        
         public void Configure(KestrelServerOptions options)
         {
-            options.ConfigureHttpsDefaults(o =>
+            if (LetsEncryptRenewalService.Certificate is LetsEncryptX509Certificate x509Certificate)
             {
-                o.ServerCertificateSelector = (_a, _b) => LetsEncryptRenewalService.Certificate;
-            });
+                options.ConfigureHttpsDefaults(o =>
+                {
+                    o.ServerCertificateSelector = (_a, _b) => x509Certificate.GetCertificate();
+                });
+            }
+            else
+            {
+                _logger.LogError("This certificate cannot be used with Kestrel");
+            }
         }
     }
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/CustomCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/CustomCertificatePersistenceStrategy.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 {
-	public class CustomCertificatePersistenceStrategy: ICertificatePersistenceStrategy
+	public class CustomCertificatePersistenceStrategy : ICertificatePersistenceStrategy
 	{
 		private readonly Func<CertificateType, byte[], Task> persistAsync;
 		private readonly Func<CertificateType, Task<byte[]>> retrieveAsync;
@@ -16,14 +17,19 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 			this.retrieveAsync = retrieveAsync;
 		}
 
-		public Task PersistAsync(CertificateType persistenceType, byte[] bytes)
+		public Task PersistAsync(CertificateType persistenceType, IPersistableCertificate certificate)
 		{
-			return persistAsync(persistenceType, bytes);
+			return persistAsync(persistenceType, certificate.RawData);
 		}
 
-		public Task<byte[]> RetrieveAsync(CertificateType persistenceType)
+		public async Task<IKeyCertificate> RetrieveAccountCertificateAsync()
 		{
-			return retrieveAsync(persistenceType);
+			return new AccountKeyCertificate(await retrieveAsync(CertificateType.Account));
+		}
+
+		public async Task<IAbstractCertificate> RetrieveSiteCertificateAsync()
+		{
+			return new LetsEncryptX509Certificate(await retrieveAsync(CertificateType.Site));
 		}
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/CustomCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/CustomCertificatePersistenceStrategy.cs
@@ -24,12 +24,22 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 
 		public async Task<IKeyCertificate> RetrieveAccountCertificateAsync()
 		{
-			return new AccountKeyCertificate(await retrieveAsync(CertificateType.Account));
+			byte[] bytes = await retrieveAsync(CertificateType.Account);
+			if (bytes == null)
+			{
+				return null;
+			}
+			return new AccountKeyCertificate(bytes);
 		}
 
 		public async Task<IAbstractCertificate> RetrieveSiteCertificateAsync()
 		{
-			return new LetsEncryptX509Certificate(await retrieveAsync(CertificateType.Site));
+			byte[] bytes = await retrieveAsync(CertificateType.Account);
+			if (bytes == null)
+			{
+				return null;
+			}
+			return new LetsEncryptX509Certificate(bytes);
 		}
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/FileCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/FileCertificatePersistenceStrategy.cs
@@ -27,12 +27,22 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 
         public async Task<IKeyCertificate> RetrieveAccountCertificateAsync()
         {
-            return new AccountKeyCertificate(await ReadFile(CertificateType.Account));
+	        var bytes = await ReadFile(CertificateType.Account);
+	        if (bytes == null)
+	        {
+		        return null;
+	        }
+	        return new AccountKeyCertificate(bytes);
         }
 
         public async Task<IAbstractCertificate> RetrieveSiteCertificateAsync()
         {
-            return new LetsEncryptX509Certificate(await ReadFile(CertificateType.Site));
+	        var bytes = await ReadFile(CertificateType.Site);
+	        if (bytes == null)
+	        {
+		        return null;
+	        }
+	        return new LetsEncryptX509Certificate(bytes);
         }
 
         private async Task<byte[]> ReadFile(CertificateType persistenceType)

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/FileCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/FileCertificatePersistenceStrategy.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 {
@@ -12,26 +13,36 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 			this.relativeFilePath = relativeFilePath;
 		}
 
-		public Task PersistAsync(CertificateType persistenceType, byte[] certificateBytes)
+        public Task PersistAsync(CertificateType persistenceType, IPersistableCertificate certificate)
 		{
 			lock (typeof(FileCertificatePersistenceStrategy))
 			{
 				File.WriteAllBytes(
 					GetCertificatePath(persistenceType),
-					certificateBytes);
+                    certificate.RawData);
 			}
 
 			return Task.CompletedTask;
 		}
 
-		public Task<byte[]> RetrieveAsync(CertificateType persistenceType)
+        public async Task<IKeyCertificate> RetrieveAccountCertificateAsync()
+        {
+            return new AccountKeyCertificate(await ReadFile(CertificateType.Account));
+        }
+
+        public async Task<IAbstractCertificate> RetrieveSiteCertificateAsync()
+        {
+            return new LetsEncryptX509Certificate(await ReadFile(CertificateType.Site));
+        }
+
+        private async Task<byte[]> ReadFile(CertificateType persistenceType)
 		{
 			lock (typeof(FileCertificatePersistenceStrategy))
 			{
 				if (!File.Exists(GetCertificatePath(persistenceType)))
-					return Task.FromResult<byte[]>(null);
+                    return null;
 
-				return Task.FromResult(File.ReadAllBytes(GetCertificatePath(persistenceType)));
+                return File.ReadAllBytes(GetCertificatePath(persistenceType));
 			}
 		}
 

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/ICertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/ICertificatePersistenceStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 {
@@ -7,11 +8,16 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 		/// <summary>
 		/// Optional. The async method to use for persisting some data for later use (if server restarts).
 		/// </summary>
-		Task PersistAsync(CertificateType persistenceType, byte[] bytes);
+		Task PersistAsync(CertificateType persistenceType, IPersistableCertificate certificate);
+		
+		/// <summary>
+		/// Optional. The async method to use for fetching previously generated data for a given key.
+		/// </summary>
+		Task<IKeyCertificate> RetrieveAccountCertificateAsync();
 
 		/// <summary>
 		/// Optional. The async method to use for fetching previously generated data for a given key.
 		/// </summary>
-		Task<byte[]> RetrieveAsync(CertificateType persistenceType);
+		Task<IAbstractCertificate> RetrieveSiteCertificateAsync();
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/IPersistenceService.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/IPersistenceService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Certes;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 {
@@ -8,10 +9,10 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 	{
 		Task<IKey> GetPersistedAccountCertificateAsync();
 		Task<ChallengeDto[]> GetPersistedChallengesAsync();
-		Task<X509Certificate2> GetPersistedSiteCertificateAsync();
+		Task<IAbstractCertificate> GetPersistedSiteCertificateAsync();
 		Task PersistAccountCertificateAsync(IKey certificate);
 		Task PersistChallengesAsync(ChallengeDto[] challenges);
-		Task PersistSiteCertificateAsync(byte[] certificateBytes);
+		Task PersistSiteCertificateAsync(IPersistableCertificate certificate);
 		Task DeleteChallengesAsync(ChallengeDto[] challenges);
 	}
 }

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryCertificatePersistenceStrategy.cs
@@ -20,7 +20,7 @@ namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 					_siteCertificate = certificate;
 					break;
 				default:
-					throw new ArgumentException("Unhandled persitence type", nameof(persistenceType));
+					throw new ArgumentException("Unhandled persistence type", nameof(persistenceType));
 			}
 			return Task.CompletedTask;
 		}

--- a/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryCertificatePersistenceStrategy.cs
+++ b/src/FluffySpoon.AspNet.LetsEncrypt/Persistence/MemoryCertificatePersistenceStrategy.cs
@@ -1,45 +1,38 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Threading.Tasks;
+using FluffySpoon.AspNet.LetsEncrypt.Certificates;
 
 namespace FluffySpoon.AspNet.LetsEncrypt.Persistence
 {
 	class MemoryCertificatePersistenceStrategy : ICertificatePersistenceStrategy
 	{
-		private IDictionary<CertificateType, byte[]> bytes;
+		IKeyCertificate _accountCertificate;
+		IAbstractCertificate _siteCertificate;
 
-		public MemoryCertificatePersistenceStrategy()
+		public Task PersistAsync(CertificateType persistenceType, IPersistableCertificate certificate)
 		{
-			bytes = new Dictionary<CertificateType, byte[]>();
-		}
-
-		public Task PersistAsync(CertificateType persistenceType, byte[] bytes)
-		{
-			if (this.bytes.ContainsKey(persistenceType))
+			switch (persistenceType)
 			{
-				if (bytes == null)
-				{
-					this.bytes.Remove(persistenceType);
-				}
-				else
-				{
-					this.bytes[persistenceType] = bytes;
-				}
-			} else {
-				if(bytes == null)
-					return Task.CompletedTask;
-				
-				this.bytes.Add(persistenceType, bytes);
+				case CertificateType.Account:
+					_accountCertificate = (IKeyCertificate)certificate;
+					break;
+				case CertificateType.Site:
+					_siteCertificate = certificate;
+					break;
+				default:
+					throw new ArgumentException("Unhandled persitence type", nameof(persistenceType));
 			}
-
 			return Task.CompletedTask;
 		}
 
-		public Task<byte[]> RetrieveAsync(CertificateType persistenceType)
+		public Task<IKeyCertificate> RetrieveAccountCertificateAsync()
 		{
-			if(bytes.ContainsKey(persistenceType))
-				return Task.FromResult(bytes[persistenceType]);
+			return Task.FromResult(_accountCertificate);
+		}
 
-			return Task.FromResult<byte[]>(null);
+		public Task<IAbstractCertificate> RetrieveSiteCertificateAsync()
+		{
+			return Task.FromResult(_siteCertificate);
 		}
 	}
 }


### PR DESCRIPTION
Sorry about this huge PR, though I did write some unit tests to show I'm a good guy really.

This is to resolve #79 - fundamentally it removes the need for Azure apps to try and retrieve X509 raw bytes, which is hard.

A few points:

* At a higher level than `byte[]`, there isn't much in common between an X509 'site' certificate and an 'account' certificate, and if you keep the single 'Retrieve' member on the strategies then you need to return a rather odd sort of type which can be both kinds of cert.  After a while of trying not to make that horrible, I ended up with separate 'Retrieve' methods.
* I am not in love with this architecture nor names of any of the new bits - very happy to have alternatives suggested.
* I kept the 'custom persistence' stuff the same, so this shouldn't break anyone's implementation of that.
* I could not make the assertion on line 148 of LetsEncryptClientTests pass.  The call is made OK, and I pass the same object to both the original call and the assertion, but somehow NSubstitute thinks they're different types of argument and I couldn't work out why, sorry.  I have left this in as a failing test in case it was really obvious to you what was happening.
* The project is slightly inconsistent as to whether class fields should have leading underscores - not sure what your preference is there - my code tends to have them, but I can clean them all up if you'd prefer that it didn't.